### PR TITLE
Update gnupg version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,12 @@ RUN set -ex \
   && (docker version || true)
 
 RUN apt-get install kubectl
+
+RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get -t stretch install gnupg2 -y \
+    && apt-get clean
+
 RUN npm -g i npm
 RUN yarn global add nodemon typescript colorguard node-gyp cypress@3.0.3 node-static mocha istanbul bower grunt-cli bower-shrinkwrap-resolver nc
 


### PR DESCRIPTION
# Update gnupg version

This PR just updates gnupg version to 2.1.18 in order to get new encryption methods available with the 2.1+ version.